### PR TITLE
Remove Some Sleeps from Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <jsr305.version>3.0.1</jsr305.version>
     <junit.version>4.12</junit.version>
-    <metrics.client.version>0.7.0</metrics.client.version>
+    <metrics.client.version>0.8.0</metrics.client.version>
     <mockito.version>1.10.19</mockito.version>
     <protobuf.version>3.1.0</protobuf.version>
     <slf4j.version>1.7.22</slf4j.version>

--- a/src/main/java/com/arpnetworking/metrics/impl/ApacheHttpSinkEventHandler.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/ApacheHttpSinkEventHandler.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Quantity;
+
+/**
+ * Interface for callbacks from client.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public interface ApacheHttpSinkEventHandler {
+
+    /**
+     * Callback invoked when a request to send samples has completed.
+     *
+     * @param records the number of records sent
+     * @param bytes the number of bytes sent
+     * @param success success or failure
+     * @param elapasedTime the elapsed time
+     */
+    void attemptComplete(long records, long bytes, boolean success, Quantity elapasedTime);
+}

--- a/src/main/java/com/arpnetworking/metrics/impl/InstrumentedApacheHttpSinkEventHandler.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/InstrumentedApacheHttpSinkEventHandler.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Metrics;
+import com.arpnetworking.metrics.MetricsFactory;
+import com.arpnetworking.metrics.Quantity;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Implementation of {@link ApacheHttpSinkEventHandler} which emits metrics
+ * periodically about the performance of the {@link ApacheHttpSink}. Although
+ * you cannot extend it through inheritance because it is final, you can
+ * extend it by encapsulating it within your own {@link ApacheHttpSinkEventHandler}
+ * implementation.
+ *
+ * TODO(ville): Convert to using PeriodicMetrics from the incubator project.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class InstrumentedApacheHttpSinkEventHandler implements ApacheHttpSinkEventHandler {
+
+    @Override
+    public void attemptComplete(
+            final long records,
+            final long bytes,
+            final boolean success,
+            final Quantity elapasedTime) {
+        try {
+            _readWriteLock.readLock().lock();
+            _metrics.incrementCounter("metrics_client/apache_http_sink/records", records);
+            _metrics.incrementCounter("metrics_client/apache_http_sink/bytes", bytes);
+            _metrics.resetCounter("metrics_client/apache_http_sink/success_rate");
+            if (success) {
+                _metrics.incrementCounter("metrics_client/apache_http_sink/success_rate");
+            }
+            _metrics.setTimer(
+                    "metrics_client/apache_http_sink/latency",
+                    elapasedTime.getValue().longValue(),
+                    elapasedTime.getUnit());
+        } finally {
+            _readWriteLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Public constructor.
+     *
+     * @param metricsFactory the {@link MetricsFactory} instance.
+     */
+    public InstrumentedApacheHttpSinkEventHandler(final MetricsFactory metricsFactory) {
+        _metricsFactory = metricsFactory;
+        _metrics = _metricsFactory.create();
+        _executorService.scheduleAtFixedRate(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        final Metrics metrics;
+                        try {
+                            _readWriteLock.writeLock().lock();
+                            metrics = _metrics;
+                            _metrics = _metricsFactory.create();
+                        } finally {
+                            _readWriteLock.writeLock().unlock();
+                        }
+                        metrics.close();
+                    }
+                },
+                DELAY_IN_MILLISECONDS,
+                DELAY_IN_MILLISECONDS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    private final MetricsFactory _metricsFactory;
+    private final ScheduledExecutorService _executorService = Executors.newSingleThreadScheduledExecutor(
+            runnable -> new Thread(runnable, "MetricsSinkApacheHttpInstrumention"));
+
+    private final ReadWriteLock _readWriteLock = new ReentrantReadWriteLock();
+    private volatile Metrics _metrics;
+
+    private static final long DELAY_IN_MILLISECONDS = 500L;
+}

--- a/src/test/java/com/arpnetworking/metrics/impl/ApacheHttpSinkTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/ApacheHttpSinkTest.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -94,8 +95,10 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(0);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -114,10 +117,7 @@ public final class ApacheHttpSinkTest {
                 createQuantityMap("gauge", TsdQuantity.newInstance(10, Units.BYTE)));
 
         sink.record(event);
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -136,8 +136,10 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(0);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -157,10 +159,7 @@ public final class ApacheHttpSinkTest {
                         "hdd_f", TsdQuantity.newInstance(100, Units.FAHRENHEIT)));
 
         sink.record(event);
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -179,8 +178,10 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(0);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -193,10 +194,7 @@ public final class ApacheHttpSinkTest {
                 createQuantityMap("gauge", TsdQuantity.newInstance(8, null)));
 
         sink.record(event);
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -215,11 +213,13 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(0);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
                 .setMaxBatchSize(10)
                 .setParallelism(1)
                 .setEmptyQueueInterval(Duration.ofMillis(1000))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -237,10 +237,7 @@ public final class ApacheHttpSinkTest {
         for (int x = 0; x < 3; x++) {
             sink.record(event);
         }
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -259,11 +256,13 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(-2);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
                 .setMaxBatchSize(2)
                 .setParallelism(1)
                 .setEmptyQueueInterval(Duration.ofMillis(1000))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -281,10 +280,7 @@ public final class ApacheHttpSinkTest {
         for (int x = 0; x < 5; x++) {
             sink.record(event);
         }
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -303,12 +299,14 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(-2);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
                 .setMaxBatchSize(2)
                 .setParallelism(1)
                 .setBufferSize(5)
                 .setEmptyQueueInterval(Duration.ofMillis(1000))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -326,10 +324,7 @@ public final class ApacheHttpSinkTest {
         for (int x = 0; x < 10; x++) {
             sink.record(event);
         }
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -348,8 +343,10 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(0);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -362,10 +359,7 @@ public final class ApacheHttpSinkTest {
                 TEST_EMPTY_SERIALIZATION_GAUGES);
 
         sink.record(event);
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -384,8 +378,10 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
+        final Semaphore semaphore = new Semaphore(0);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -398,10 +394,7 @@ public final class ApacheHttpSinkTest {
                 createQuantityMap("gauge", TsdQuantity.newInstance(8, Units.ROTATION)));
 
         sink.record(event);
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
@@ -420,8 +413,10 @@ public final class ApacheHttpSinkTest {
                 .willReturn(WireMock.aResponse()
                         .withStatus(400)));
 
+        final Semaphore semaphore = new Semaphore(0);
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final TsdEvent event = new TsdEvent(
@@ -431,10 +426,7 @@ public final class ApacheHttpSinkTest {
                 TEST_EMPTY_SERIALIZATION_GAUGES);
 
         sink.record(event);
-
-        // TODO(ville): Replace this with a trigger, logical logic, etc.
-        // NOTE: This had to be increased because the connection is now established in parallel
-        Thread.sleep(3000);
+        semaphore.acquire();
 
         // Request matcher
         final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))

--- a/src/test/java/com/arpnetworking/metrics/impl/InstrumentedApacheHttpSinkEventHandlerTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/InstrumentedApacheHttpSinkEventHandlerTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Metrics;
+import com.arpnetworking.metrics.MetricsFactory;
+import com.arpnetworking.metrics.Units;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * Tests for {@link InstrumentedApacheHttpSinkEventHandler}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class InstrumentedApacheHttpSinkEventHandlerTest {
+
+    @Test
+    public void test() throws InterruptedException {
+        final Semaphore semaphore = new Semaphore(-2);
+
+        final MetricsFactory metricsFactory = Mockito.mock(MetricsFactory.class);
+        final Metrics metricsA = Mockito.mock(Metrics.class, "A");
+        final Metrics metricsB = Mockito.mock(Metrics.class, "B");
+
+        Mockito.doAnswer(ignored -> {
+            try {
+                if (semaphore.availablePermits() == -2) {
+                    return metricsA;
+                } else {
+                    return metricsB;
+                }
+            } finally {
+                semaphore.release();
+            }
+        }).when(metricsFactory).create();
+
+        final ApacheHttpSinkEventHandler eventHandler = new InstrumentedApacheHttpSinkEventHandler(metricsFactory);
+        eventHandler.attemptComplete(1, 2, true, TsdQuantity.newInstance(123, Units.NANOSECOND));
+        eventHandler.attemptComplete(3, 4, false, TsdQuantity.newInstance(246, Units.NANOSECOND));
+        semaphore.acquire();
+
+        Mockito.verify(metricsFactory, Mockito.times(3)).create();
+        Mockito.verify(metricsA).incrementCounter("metrics_client/apache_http_sink/records", 1);
+        Mockito.verify(metricsA).incrementCounter("metrics_client/apache_http_sink/records", 3);
+        Mockito.verify(metricsA).incrementCounter("metrics_client/apache_http_sink/bytes", 2);
+        Mockito.verify(metricsA).incrementCounter("metrics_client/apache_http_sink/bytes", 4);
+        Mockito.verify(metricsA, Mockito.times(2)).resetCounter("metrics_client/apache_http_sink/success_rate");
+        Mockito.verify(metricsA).incrementCounter("metrics_client/apache_http_sink/success_rate");
+        Mockito.verify(metricsA).setTimer("metrics_client/apache_http_sink/latency", 123, Units.NANOSECOND);
+        Mockito.verify(metricsA).setTimer("metrics_client/apache_http_sink/latency", 246, Units.NANOSECOND);
+        Mockito.verify(metricsA).close();
+        Mockito.verifyNoMoreInteractions(metricsA);
+    }
+}


### PR DESCRIPTION
Removed the sleeps waiting for data in the tests by introducing an event handler. Added an event handler implementation that instruments the metrics client.

* This addresses #3.
* This depends on https://github.com/ArpNetworking/metrics-client-java/issues/10.