### PR TITLE
Improved tests and added dropped event metrics.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
     <maven.shade.plugin.version>2.4.3</maven.shade.plugin.version>
 
     <!-- Code Coverage -->
-    <jacoco.check.line.coverage>0.95</jacoco.check.line.coverage>
-    <jacoco.check.branch.coverage>0.89</jacoco.check.branch.coverage>
+    <jacoco.check.line.coverage>0.99</jacoco.check.line.coverage>
+    <jacoco.check.branch.coverage>0.92</jacoco.check.branch.coverage>
   </properties>
   <build>
     <plugins>

--- a/src/main/java/com/arpnetworking/metrics/impl/ApacheHttpSinkEventHandler.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/ApacheHttpSinkEventHandler.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.impl;
 
+import com.arpnetworking.metrics.Event;
 import com.arpnetworking.metrics.Quantity;
 
 /**
@@ -33,4 +34,11 @@ public interface ApacheHttpSinkEventHandler {
      * @param elapasedTime the elapsed time
      */
     void attemptComplete(long records, long bytes, boolean success, Quantity elapasedTime);
+
+    /**
+     * Callback invoked when an {@link Event} is dropped from the queue.
+     *
+     * @param event the {@link Event} dropped from the queue
+     */
+    void droppedEvent(Event event);
 }

--- a/src/test/java/com/arpnetworking/metrics/impl/ApacheHttpSinkTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/ApacheHttpSinkTest.java
@@ -15,37 +15,56 @@
  */
 package com.arpnetworking.metrics.impl;
 
+import com.arpnetworking.metrics.Event;
 import com.arpnetworking.metrics.Quantity;
 import com.arpnetworking.metrics.Sink;
 import com.arpnetworking.metrics.Units;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.matching.ValueMatcher;
+import com.inscopemetrics.client.protocol.ClientV1;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
+import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Tests for {@link ApacheHttpSink}.
  *
  * @author Brandon Arp (brandon dot arp at inscopemetrics dot com)
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
  */
 public final class ApacheHttpSinkTest {
 
@@ -65,6 +84,7 @@ public final class ApacheHttpSinkTest {
         builder.setMaxBatchSize(null);
         builder.setEmptyQueueInterval(null);
         builder.setDispatchErrorLoggingInterval(null);
+        builder.setEventsDroppedLoggingInteval(null);
         builder.setEmptyQueueInterval(null);
         final Sink sink = builder.build();
         Assert.assertNotNull(sink);
@@ -91,14 +111,764 @@ public final class ApacheHttpSinkTest {
 
     @Test
     public void testPostSuccess() throws InterruptedException {
+        final String start = Instant.now().minusMillis(812).atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_INSTANT);
+        final String end = Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_INSTANT);
+        final String id = UUID.randomUUID().toString();
+
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            // Annotations
+                            Assert.assertEquals(7, r.getAnnotationsCount());
+                            assertAnnotation(r.getAnnotationsList(), "foo", "bar");
+                            assertAnnotation(r.getAnnotationsList(), "_service", "myservice");
+                            assertAnnotation(r.getAnnotationsList(), "_cluster", "mycluster");
+                            assertAnnotation(r.getAnnotationsList(), "_start", start);
+                            assertAnnotation(r.getAnnotationsList(), "_end", end);
+                            assertAnnotation(r.getAnnotationsList(), "_id", id);
+
+                            // Dimensions
+                            Assert.assertEquals(3, r.getDimensionsCount());
+                            assertDimension(r.getDimensionsList(), "host", "some.host.com");
+                            assertDimension(r.getDimensionsList(), "service", "myservice");
+                            assertDimension(r.getDimensionsList(), "cluster", "mycluster");
+
+                            // Samples
+                            assertSample(
+                                    r.getTimersList(),
+                                    "timer",
+                                    123d,
+                                    ClientV1.Unit.Type.SECOND,
+                                    ClientV1.Unit.Scale.NANO);
+                            assertSample(
+                                    r.getCountersList(),
+                                    "counter",
+                                    8d);
+                            assertSample(
+                                    r.getGaugesList(),
+                                    "gauge",
+                                    10d,
+                                    ClientV1.Unit.Type.BYTE,
+                                    ClientV1.Unit.Scale.UNIT);
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)));
+
+        final AtomicBoolean assertionResult = new AtomicBoolean(false);
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler(
+                        new AttemptCompletedAssertionHandler(
+                                assertionResult,
+                                1,
+                                377,
+                                true,
+                                new CompletionHandler(
+                                        semaphore)))
+                .build();
+
+        final Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("foo", "bar");
+        annotations.put("_start", start);
+        annotations.put("_end", end);
+        annotations.put("_host", "some.host.com");
+        annotations.put("_service", "myservice");
+        annotations.put("_cluster", "mycluster");
+        annotations.put("_id", id);
+
+        final TsdEvent event = new TsdEvent(
+                annotations,
+                createQuantityMap("timer", TsdQuantity.newInstance(123, Units.NANOSECOND)),
+                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
+                createQuantityMap("gauge", TsdQuantity.newInstance(10, Units.BYTE)));
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Ensure expected handler was invoked
+        Assert.assertTrue(assertionResult.get());
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(1, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testCompoundUnits() throws InterruptedException {
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            // Annotations
+                            Assert.assertEquals(0, r.getAnnotationsCount());
+
+                            // Dimensions
+                            Assert.assertEquals(0, r.getDimensionsCount());
+
+                            // Samples
+                            Assert.assertEquals(0, r.getTimersCount());
+                            Assert.assertEquals(0, r.getTimersCount());
+                            assertSample(
+                                    r.getGaugesList(),
+                                    "gauge",
+                                    10d,
+                                    ClientV1.Unit.Type.BIT,
+                                    ClientV1.Unit.Scale.UNIT,
+                                    ClientV1.Unit.Type.SECOND,
+                                    ClientV1.Unit.Scale.UNIT);
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)));
+
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler(new CompletionHandler(semaphore))
+                .build();
+
+        final TsdEvent event = new TsdEvent(
+                Collections.emptyMap(),
+                createQuantityMap(),
+                createQuantityMap(),
+                createQuantityMap("gauge", TsdQuantity.newInstance(10, Units.BITS_PER_SECOND)));
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(1, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testNoUnits() throws InterruptedException {
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            // Annotations
+                            Assert.assertEquals(0, r.getAnnotationsCount());
+
+                            // Dimensions
+                            Assert.assertEquals(0, r.getDimensionsCount());
+
+                            // Samples
+                            assertSample(
+                                    r.getTimersList(),
+                                    "timer",
+                                    7d);
+                            assertSample(
+                                    r.getCountersList(),
+                                    "counter",
+                                    8d);
+                            assertSample(
+                                    r.getGaugesList(),
+                                    "gauge",
+                                    9d);
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)));
+
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler(new CompletionHandler(semaphore))
+                .build();
+
+        final TsdEvent event = new TsdEvent(
+                Collections.emptyMap(),
+                createQuantityMap("timer", TsdQuantity.newInstance(7, null)),
+                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
+                createQuantityMap("gauge", TsdQuantity.newInstance(9, null)));
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(1, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testBatchesRequests() throws InterruptedException {
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            // Annotations
+                            Assert.assertEquals(0, r.getAnnotationsCount());
+
+                            // Dimensions
+                            Assert.assertEquals(0, r.getDimensionsCount());
+
+                            // Samples
+                            assertSample(
+                                    r.getTimersList(),
+                                    "timer",
+                                    7d);
+                            assertSample(
+                                    r.getCountersList(),
+                                    "counter",
+                                    8d);
+                            assertSample(
+                                    r.getGaugesList(),
+                                    "gauge",
+                                    9d);
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)));
+
+        final AtomicBoolean assertionResult = new AtomicBoolean(false);
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setMaxBatchSize(10)
+                .setParallelism(1)
+                .setEmptyQueueInterval(Duration.ofMillis(1000))
+                .setEventHandler(
+                        new AttemptCompletedAssertionHandler(
+                                assertionResult,
+                                3,
+                                210,
+                                true,
+                                new CompletionHandler(
+                                        semaphore)))
+                .build();
+
+        final TsdEvent event = new TsdEvent(
+                Collections.emptyMap(),
+                createQuantityMap("timer", TsdQuantity.newInstance(7, null)),
+                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
+                createQuantityMap("gauge", TsdQuantity.newInstance(9, null)));
+
+        for (int x = 0; x < 3; x++) {
+            sink.record(event);
+        }
+        semaphore.acquire();
+
+        // Ensure expected handler was invoked
+        Assert.assertTrue(assertionResult.get());
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(1, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testBatchesRequestsRespectsMax() throws InterruptedException {
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            // Annotations
+                            Assert.assertEquals(0, r.getAnnotationsCount());
+
+                            // Dimensions
+                            Assert.assertEquals(0, r.getDimensionsCount());
+
+                            // Samples
+                            assertSample(
+                                    r.getTimersList(),
+                                    "timer",
+                                    7d);
+                            assertSample(
+                                    r.getCountersList(),
+                                    "counter",
+                                    8d);
+                            assertSample(
+                                    r.getGaugesList(),
+                                    "gauge",
+                                    9d);
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)));
+
+        final Semaphore semaphore = new Semaphore(-2);
+        final Sink sink = new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setMaxBatchSize(2)
+                .setParallelism(1)
+                .setEmptyQueueInterval(Duration.ofMillis(1000))
+                .setEventHandler(new CompletionHandler(semaphore))
+                .build();
+
+        final TsdEvent event = new TsdEvent(
+                Collections.emptyMap(),
+                createQuantityMap("timer", TsdQuantity.newInstance(7, null)),
+                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
+                createQuantityMap("gauge", TsdQuantity.newInstance(9, null)));
+
+        for (int x = 0; x < 5; x++) {
+            sink.record(event);
+        }
+        semaphore.acquire();
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(3, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testRespectsBufferMax() throws InterruptedException {
+        final AtomicInteger droppedEvents = new AtomicInteger(0);
+        final Semaphore semaphoreA = new Semaphore(0);
+        final Semaphore semaphoreB = new Semaphore(0);
+        final Semaphore semaphoreC = new Semaphore(-2);
+        final AtomicInteger recordsReceived = new AtomicInteger(0);
+
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            recordsReceived.incrementAndGet();
+
+                            // Annotations
+                            Assert.assertEquals(0, r.getAnnotationsCount());
+
+                            // Dimensions
+                            Assert.assertEquals(0, r.getDimensionsCount());
+
+                            // Samples
+                            assertSample(
+                                    r.getTimersList(),
+                                    "timer",
+                                    7d);
+                            assertSample(
+                                    r.getCountersList(),
+                                    "counter",
+                                    8d);
+                            assertSample(
+                                    r.getGaugesList(),
+                                    "gauge",
+                                    9d);
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)));
+
+        final Sink sink = new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setMaxBatchSize(2)
+                .setParallelism(1)
+                .setBufferSize(5)
+                .setEmptyQueueInterval(Duration.ofMillis(1000))
+                .setEventHandler(new RespectsMaxBufferEventHandler(semaphoreA, semaphoreB, semaphoreC, droppedEvents))
+                .build();
+
+        final TsdEvent event = new TsdEvent(
+                Collections.emptyMap(),
+                createQuantityMap("timer", TsdQuantity.newInstance(7, null)),
+                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
+                createQuantityMap("gauge", TsdQuantity.newInstance(9, null)));
+
+        // Add one event to be used as a synchronization point
+        sink.record(event);
+        semaphoreA.acquire();
+
+        // Add the actual events to analyze
+        for (int x = 0; x < 10; x++) {
+            sink.record(event);
+        }
+        semaphoreB.release();
+        semaphoreC.acquire();
+
+        // Ensure expected handler was invoked
+        Assert.assertEquals(5, droppedEvents.get());
+
+        // Assert number of records received
+        Assert.assertEquals(6, recordsReceived.get());
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(4, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testCustomUnit() throws InterruptedException {
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            // Annotations
+                            Assert.assertEquals(0, r.getAnnotationsCount());
+
+                            // Dimensions
+                            Assert.assertEquals(0, r.getDimensionsCount());
+
+                            // Samples
+                            assertSample(
+                                    r.getTimersList(),
+                                    "timer",
+                                    8d);
+                            Assert.assertEquals(0, r.getCountersCount());
+                            Assert.assertEquals(0, r.getGaugesCount());
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(200)));
+
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler(new CompletionHandler(semaphore))
+                .build();
+
+        final TsdEvent event = new TsdEvent(
+                Collections.emptyMap(),
+                createQuantityMap("timer", TsdQuantity.newInstance(8, () -> "Foo")),
+                TEST_EMPTY_SERIALIZATION_COUNTERS,
+                TEST_EMPTY_SERIALIZATION_GAUGES);
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(1, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testPostFailure() throws InterruptedException {
+        _wireMockRule.stubFor(
+                WireMock.requestMatching(new RequestValueMatcher(
+                        r -> {
+                            // Annotations
+                            Assert.assertEquals(0, r.getAnnotationsCount());
+
+                            // Dimensions
+                            Assert.assertEquals(0, r.getDimensionsCount());
+
+                            // Samples
+                            Assert.assertEquals(0, r.getTimersCount());
+                            Assert.assertEquals(0, r.getCountersCount());
+                            Assert.assertEquals(0, r.getGaugesCount());
+                        }))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(400)));
+
+        final AtomicBoolean assertionResult = new AtomicBoolean(false);
+        final Semaphore semaphore = new Semaphore(0);
+        final org.slf4j.Logger logger = Mockito.mock(org.slf4j.Logger.class);
+        final Sink sink = new ApacheHttpSink(
+                new ApacheHttpSink.Builder()
+                        .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                        .setEventHandler(
+                                new AttemptCompletedAssertionHandler(
+                                        assertionResult,
+                                        1,
+                                        2,
+                                        false,
+                                        new CompletionHandler(
+                                                semaphore))),
+                logger);
+
+        final TsdEvent event = new TsdEvent(
+                ANNOTATIONS,
+                TEST_EMPTY_SERIALIZATION_TIMERS,
+                TEST_EMPTY_SERIALIZATION_COUNTERS,
+                TEST_EMPTY_SERIALIZATION_GAUGES);
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Ensure expected handler was invoked
+        Assert.assertTrue(assertionResult.get());
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(1, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+
+        // Assert that an IOException was captured
+        Mockito.verify(logger).error(
+                Matchers.startsWith("Received failure response when sending metrics to HTTP endpoint; uri="));
+    }
+
+    @Test
+    public void testPostBadHost() throws InterruptedException {
+        final org.slf4j.Logger logger = Mockito.mock(org.slf4j.Logger.class);
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink(
+                new ApacheHttpSink.Builder()
+                        .setUri(URI.create("http://nohost.example.com" + PATH))
+                        .setEventHandler(new CompletionHandler(semaphore)),
+                logger);
+
+        final TsdEvent event = new TsdEvent(
+                ANNOTATIONS,
+                TEST_EMPTY_SERIALIZATION_TIMERS,
+                TEST_EMPTY_SERIALIZATION_COUNTERS,
+                TEST_EMPTY_SERIALIZATION_GAUGES);
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that no data was sent
+        _wireMockRule.verify(0, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+
+        // Assert that an IOException was captured
+        Mockito.verify(logger).error(
+                Matchers.startsWith("Encountered failure when sending metrics to HTTP endpoint; uri="),
+                Matchers.any(IOException.class));
+    }
+
+    @Test
+    public void testHttpClientExecuteException() throws InterruptedException {
+        final CloseableHttpClient httpClient = Mockito.mock(
+                CloseableHttpClient.class,
+                (Answer) invocationOnMock -> {
+                    throw new NullPointerException("Throw by default");
+                });
+
+        final org.slf4j.Logger logger = Mockito.mock(org.slf4j.Logger.class);
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink(
+                new ApacheHttpSink.Builder()
+                        .setUri(URI.create("http://nohost.example.com" + PATH))
+                        .setEventHandler(new CompletionHandler(semaphore)),
+                () -> httpClient,
+                logger);
+
+        final TsdEvent event = new TsdEvent(
+                ANNOTATIONS,
+                TEST_EMPTY_SERIALIZATION_TIMERS,
+                TEST_EMPTY_SERIALIZATION_COUNTERS,
+                TEST_EMPTY_SERIALIZATION_GAUGES);
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that no data was sent
+        _wireMockRule.verify(0, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+
+        // Assert that the runtime exception was captured
+        Mockito.verify(logger).error(
+                Matchers.startsWith("Encountered failure when sending metrics to HTTP endpoint; uri="),
+                Matchers.any(NullPointerException.class));
+    }
+
+    @Test
+    public void testHttpClientResponseException() throws InterruptedException, IOException {
+        final CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        final CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+        Mockito.doReturn(httpResponse).when(httpClient).execute(Mockito.any(HttpPost.class));
+        Mockito.doThrow(new NullPointerException("Throw by default")).when(httpResponse).getStatusLine();
+
+        final org.slf4j.Logger logger = Mockito.mock(org.slf4j.Logger.class);
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink(
+                new ApacheHttpSink.Builder()
+                        .setUri(URI.create("http://nohost.example.com" + PATH))
+                        .setEventHandler(new CompletionHandler(semaphore)),
+                () -> httpClient,
+                logger);
+
+        final TsdEvent event = new TsdEvent(
+                ANNOTATIONS,
+                TEST_EMPTY_SERIALIZATION_TIMERS,
+                TEST_EMPTY_SERIALIZATION_COUNTERS,
+                TEST_EMPTY_SERIALIZATION_GAUGES);
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Verify mocks
+        Mockito.verify(httpClient).execute(Mockito.any(HttpPost.class));
+        Mockito.verifyNoMoreInteractions(httpClient);
+        Mockito.verify(httpResponse).getStatusLine();
+        Mockito.verify(httpResponse).close();
+        Mockito.verifyNoMoreInteractions(httpResponse);
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that no data was sent
+        _wireMockRule.verify(0, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+
+        // Assert that the runtime exception was captured
+        Mockito.verify(logger).error(
+                Matchers.startsWith("Encountered failure when sending metrics to HTTP endpoint; uri="),
+                Matchers.any(NullPointerException.class));
+    }
+
+    @Test
+    public void testHttpClientResponseCloseException() throws InterruptedException, IOException {
+        final CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        final CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+        Mockito.doReturn(httpResponse).when(httpClient).execute(Mockito.any(HttpPost.class));
+        Mockito.doThrow(new NullPointerException("Throw by default")).when(httpResponse).getStatusLine();
+        Mockito.doThrow(new IllegalStateException("Throw by default")).when(httpResponse).close();
+
+        final org.slf4j.Logger logger = Mockito.mock(org.slf4j.Logger.class);
+        final Semaphore semaphore = new Semaphore(0);
+        final Sink sink = new ApacheHttpSink(
+                new ApacheHttpSink.Builder()
+                        .setUri(URI.create("http://nohost.example.com" + PATH))
+                        .setEventHandler(new CompletionHandler(semaphore)),
+                () -> httpClient,
+                logger);
+
+        final TsdEvent event = new TsdEvent(
+                ANNOTATIONS,
+                TEST_EMPTY_SERIALIZATION_TIMERS,
+                TEST_EMPTY_SERIALIZATION_COUNTERS,
+                TEST_EMPTY_SERIALIZATION_GAUGES);
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Verify mocks
+        Mockito.verify(httpClient).execute(Mockito.any(HttpPost.class));
+        Mockito.verifyNoMoreInteractions(httpClient);
+        Mockito.verify(httpResponse).getStatusLine();
+        Mockito.verify(httpResponse).close();
+        Mockito.verifyNoMoreInteractions(httpResponse);
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that no data was sent
+        _wireMockRule.verify(0, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+
+        // Assert that the runtime exception was captured
+        Mockito.verify(logger).error(
+                Matchers.startsWith("Encountered failure when sending metrics to HTTP endpoint; uri="),
+                Matchers.any(IllegalStateException.class));
+    }
+
+    @Test
+    public void testHttpClientSupplierException() throws InterruptedException, IOException {
+        final org.slf4j.Logger logger = Mockito.mock(org.slf4j.Logger.class);
+        final Semaphore semaphore = new Semaphore(0);
+        final ApacheHttpSinkEventHandler handler = Mockito.mock(ApacheHttpSinkEventHandler.class);
+        final Sink sink = new ApacheHttpSink(
+                new ApacheHttpSink.Builder()
+                        .setUri(URI.create("http://nohost.example.com" + PATH))
+                        .setEventHandler(handler),
+                () -> {
+                    semaphore.release();
+                    throw new IllegalStateException("Test Exception");
+                },
+                logger);
+
+        final TsdEvent event = new TsdEvent(
+                ANNOTATIONS,
+                TEST_EMPTY_SERIALIZATION_TIMERS,
+                TEST_EMPTY_SERIALIZATION_COUNTERS,
+                TEST_EMPTY_SERIALIZATION_GAUGES);
+
+        sink.record(event);
+        semaphore.acquire();
+
+        // Assert that the runtime exception was captured
+        Mockito.verify(logger, Mockito.timeout(1000)).error(
+                Matchers.startsWith("MetricsSinkApacheHttpWorker failure"),
+                Matchers.any(IllegalStateException.class));
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that no data was sent
+        _wireMockRule.verify(0, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+
+        // Verify no handler was invoked
+        Mockito.verify(handler, Mockito.never()).attemptComplete(
+                Mockito.anyLong(),
+                Mockito.anyLong(),
+                Mockito.anyBoolean(),
+                Mockito.any(Quantity.class));
+    }
+
+    @Test
+    public void testStop() throws InterruptedException {
         _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)));
 
         final Semaphore semaphore = new Semaphore(0);
+        @SuppressWarnings("unchecked")
+        final ApacheHttpSink sink = (ApacheHttpSink) new ApacheHttpSink.Builder()
+                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
+                .setEventHandler(new CompletionHandler(semaphore))
+                .build();
+
+        final Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("foo", "bar");
+        annotations.put("_start", Instant.now().minusMillis(812).atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_INSTANT));
+        annotations.put("_end", Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_INSTANT));
+        annotations.put("_host", "some.host.com");
+        annotations.put("_service", "myservice");
+        annotations.put("_cluster", "mycluster");
+        annotations.put("_id", UUID.randomUUID().toString());
+
+        final TsdEvent event = new TsdEvent(
+                annotations,
+                createQuantityMap("timer", TsdQuantity.newInstance(123, Units.NANOSECOND)),
+                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
+                createQuantityMap("gauge", TsdQuantity.newInstance(10, Units.BYTE)));
+
+        sink.stop();
+        Thread.sleep(1000);
+        sink.record(event);
+        Assert.assertFalse(semaphore.tryAcquire(1, TimeUnit.SECONDS));
+
+        // Request matcher
+        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
+                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
+
+        // Assert that data was sent
+        _wireMockRule.verify(0, requestPattern);
+        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
+    }
+
+    @Test
+    public void testNoEventHandler() throws InterruptedException {
+        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)));
+
         final Sink sink = new ApacheHttpSink.Builder()
                 .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
                 .build();
 
         final Map<String, String> annotations = new LinkedHashMap<>();
@@ -117,347 +887,6 @@ public final class ApacheHttpSinkTest {
                 createQuantityMap("gauge", TsdQuantity.newInstance(10, Units.BYTE)));
 
         sink.record(event);
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(1, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testCompoundUnits() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)));
-
-        final Semaphore semaphore = new Semaphore(0);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("foo", "bar");
-
-        final TsdEvent event = new TsdEvent(
-                annotations,
-                createQuantityMap("timer", TsdQuantity.newInstance(123, Units.NANOSECOND),
-                        "minutes", TsdQuantity.newInstance(5, Units.MINUTE),
-                        "hours", TsdQuantity.newInstance(5, Units.HOUR),
-                        "day", TsdQuantity.newInstance(5, Units.DAY),
-                        "week", TsdQuantity.newInstance(5, Units.WEEK)),
-                createQuantityMap("counter", TsdQuantity.newInstance(8, Units.BYTE)),
-                createQuantityMap("gauge", TsdQuantity.newInstance(10, Units.BITS_PER_SECOND),
-                        "hdd_c", TsdQuantity.newInstance(40, Units.CELSIUS),
-                        "hdd_k", TsdQuantity.newInstance(400, Units.KELVIN),
-                        "hdd_f", TsdQuantity.newInstance(100, Units.FAHRENHEIT)));
-
-        sink.record(event);
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(1, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testNoUnits() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)));
-
-        final Semaphore semaphore = new Semaphore(0);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("foo", "bar");
-
-        final TsdEvent event = new TsdEvent(
-                annotations,
-                createQuantityMap("timer", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("gauge", TsdQuantity.newInstance(8, null)));
-
-        sink.record(event);
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(1, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testBatchesRequests() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)));
-
-        final Semaphore semaphore = new Semaphore(0);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setMaxBatchSize(10)
-                .setParallelism(1)
-                .setEmptyQueueInterval(Duration.ofMillis(1000))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("foo", "bar");
-
-        final TsdEvent event = new TsdEvent(
-                annotations,
-                createQuantityMap("timer", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("gauge", TsdQuantity.newInstance(8, null)));
-
-        // TODO(ville): This is trying to synchronize the two sleeps - WTF.
-        // This use case is likely best served with a sleeper much like in MAD.
-        Thread.sleep(500);
-        for (int x = 0; x < 3; x++) {
-            sink.record(event);
-        }
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(1, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testBatchesRequestsRespectsMax() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)));
-
-        final Semaphore semaphore = new Semaphore(-2);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setMaxBatchSize(2)
-                .setParallelism(1)
-                .setEmptyQueueInterval(Duration.ofMillis(1000))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("foo", "bar");
-
-        final TsdEvent event = new TsdEvent(
-                annotations,
-                createQuantityMap("timer", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("gauge", TsdQuantity.newInstance(8, null)));
-
-        // TODO(ville): This is trying to synchronize the two sleeps - WTF.
-        // This use case is likely best served with a sleeper much like in MAD.
-        Thread.sleep(500);
-        for (int x = 0; x < 5; x++) {
-            sink.record(event);
-        }
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(3, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testRespectsBufferMax() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)));
-
-        final Semaphore semaphore = new Semaphore(-2);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setMaxBatchSize(2)
-                .setParallelism(1)
-                .setBufferSize(5)
-                .setEmptyQueueInterval(Duration.ofMillis(1000))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("foo", "bar");
-
-        final TsdEvent event = new TsdEvent(
-                annotations,
-                createQuantityMap("timer", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("counter", TsdQuantity.newInstance(8, null)),
-                createQuantityMap("gauge", TsdQuantity.newInstance(8, null)));
-
-        // TODO(ville): This is trying to synchronize the two sleeps - WTF.
-        // This use case is likely best served with a sleeper much like in MAD.
-        Thread.sleep(500);
-        for (int x = 0; x < 10; x++) {
-            sink.record(event);
-        }
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(3, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testCustomUnit() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)));
-
-        final Semaphore semaphore = new Semaphore(0);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("foo", "bar");
-
-        final TsdEvent event = new TsdEvent(
-                annotations,
-                createQuantityMap("timer", TsdQuantity.newInstance(8, () -> "Foo")),
-                TEST_EMPTY_SERIALIZATION_COUNTERS,
-                TEST_EMPTY_SERIALIZATION_GAUGES);
-
-        sink.record(event);
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(1, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testUnsupportedBaseUnit() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)));
-
-        final Semaphore semaphore = new Semaphore(0);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("foo", "bar");
-
-        final TsdEvent event = new TsdEvent(
-                annotations,
-                createQuantityMap("timer", TsdQuantity.newInstance(8, Units.ROTATION)),
-                createQuantityMap("counter", TsdQuantity.newInstance(8, Units.ROTATION)),
-                createQuantityMap("gauge", TsdQuantity.newInstance(8, Units.ROTATION)));
-
-        sink.record(event);
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(1, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-    }
-
-    @Test
-    public void testPostFailure() throws InterruptedException {
-        _wireMockRule.stubFor(WireMock.post(WireMock.urlEqualTo(PATH))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(400)));
-
-        final Semaphore semaphore = new Semaphore(0);
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://localhost:" + _wireMockRule.port() + PATH))
-                .setEventHandler((records, bytes, success, elapasedTime) -> semaphore.release())
-                .build();
-
-        final TsdEvent event = new TsdEvent(
-                ANNOTATIONS,
-                TEST_EMPTY_SERIALIZATION_TIMERS,
-                TEST_EMPTY_SERIALIZATION_COUNTERS,
-                TEST_EMPTY_SERIALIZATION_GAUGES);
-
-        sink.record(event);
-        semaphore.acquire();
-
-        // Request matcher
-        final RequestPatternBuilder requestPattern = WireMock.postRequestedFor(WireMock.urlEqualTo(PATH))
-                .withHeader("Content-Type", WireMock.equalTo("application/octet-stream"));
-
-        //TODO(ville): Actually assert that the expected data was sent.
-
-        // Assert that data was sent
-        _wireMockRule.verify(1, requestPattern);
-        Assert.assertTrue(_wireMockRule.findUnmatchedRequests().getRequests().isEmpty());
-
-        //TODO(ville): Actually assert that the failure was handled; e.g. getLogger event.
-    }
-
-    @Test
-    public void testPostBadHost() throws InterruptedException {
-        final Sink sink = new ApacheHttpSink.Builder()
-                .setUri(URI.create("http://nohost.example.com" + PATH))
-                .build();
-        final TsdEvent event = new TsdEvent(
-                ANNOTATIONS,
-                TEST_EMPTY_SERIALIZATION_TIMERS,
-                TEST_EMPTY_SERIALIZATION_COUNTERS,
-                TEST_EMPTY_SERIALIZATION_GAUGES);
-        sink.record(event);
-
-        // TODO(ville): There should be some record of failure; we should assert that.
-        // So with retries the bad request would go around a few times and then get
-        // dropped. When it does an injected logger should spout a warning. That's the
-        // only effect we have of this case executing properly, and we should assert
-        // that (much as we do in the metrics client java).
     }
 
     @Test
@@ -513,6 +942,107 @@ public final class ApacheHttpSinkTest {
         return map;
     }
 
+    private static void assertSample(
+            final List<ClientV1.MetricEntry> samples,
+            final String name,
+            final double value) {
+        assertSample(samples, name, value, null);
+    }
+
+    private void assertSample(
+            final List<ClientV1.MetricEntry> samples,
+            final String name,
+            final double value,
+            final ClientV1.Unit.Type numeratorUnitType,
+            final ClientV1.Unit.Scale numeratorUnitScale,
+            final ClientV1.Unit.Type denominatorUnitType,
+            final ClientV1.Unit.Scale denominatorUnitScale) {
+        assertSample(
+                samples,
+                name,
+                value,
+                ClientV1.CompoundUnit.newBuilder()
+                        .addNumerator(
+                                0,
+                                ClientV1.Unit.newBuilder()
+                                        .setScale(numeratorUnitScale)
+                                        .setType(numeratorUnitType)
+                                        .build())
+                        .addDenominator(
+                                0,
+                                ClientV1.Unit.newBuilder()
+                                        .setScale(denominatorUnitScale)
+                                        .setType(denominatorUnitType)
+                                        .build())
+                        .build());
+    }
+
+    private static void assertSample(
+            final List<ClientV1.MetricEntry> samples,
+            final String name,
+            final double value,
+            final ClientV1.Unit.Type unitType,
+            final ClientV1.Unit.Scale unitScale) {
+        assertSample(
+                samples,
+                name,
+                value,
+                ClientV1.CompoundUnit.newBuilder()
+                        .addNumerator(
+                                0,
+                                ClientV1.Unit.newBuilder()
+                                        .setScale(unitScale)
+                                        .setType(unitType)
+                                        .build())
+                        .build());
+    }
+
+    private static void assertSample(
+            final List<ClientV1.MetricEntry> samples,
+            final String name,
+            final double value,
+            @Nullable final ClientV1.CompoundUnit compoundUnit) {
+
+        final ClientV1.DoubleQuantity.Builder protobufSample = ClientV1.DoubleQuantity.newBuilder().setValue(value);
+        if (compoundUnit != null) {
+            protobufSample.setUnit(compoundUnit);
+        } else {
+            protobufSample.setUnit(ClientV1.CompoundUnit.newBuilder().build());
+        }
+
+        Assert.assertTrue(
+                String.format("Missing sample: name=%s, value=%f", name, value),
+                samples.contains(
+                        ClientV1.MetricEntry.newBuilder()
+                                .setName(name)
+                                .addSamples(
+                                        0,
+                                        protobufSample.build())
+                                .build()));
+    }
+
+    private static void assertAnnotation(
+            final List<ClientV1.AnnotationEntry> annotations,
+            final String name,
+            final String value) {
+        Assert.assertTrue(annotations.contains(
+                ClientV1.AnnotationEntry.newBuilder()
+                        .setName(name)
+                        .setValue(value)
+                        .build()));
+    }
+
+    private static void assertDimension(
+            final List<ClientV1.DimensionEntry> dimensions,
+            final String name,
+            final String value) {
+        Assert.assertTrue(dimensions.contains(
+                ClientV1.DimensionEntry.newBuilder()
+                        .setName(name)
+                        .setValue(value)
+                        .build()));
+    }
+
     @Rule
     public WireMockRule _wireMockRule = new WireMockRule(
             WireMockConfiguration.wireMockConfig().dynamicPort());
@@ -522,4 +1052,209 @@ public final class ApacheHttpSinkTest {
     private static final Map<String, List<Quantity>> TEST_EMPTY_SERIALIZATION_TIMERS = createQuantityMap();
     private static final Map<String, List<Quantity>> TEST_EMPTY_SERIALIZATION_COUNTERS = createQuantityMap();
     private static final Map<String, List<Quantity>> TEST_EMPTY_SERIALIZATION_GAUGES = createQuantityMap();
+
+    private static final class RespectsMaxBufferEventHandler implements ApacheHttpSinkEventHandler {
+        private final Semaphore _semaphoreA;
+        private final Semaphore _semaphoreB;
+        private final Semaphore _semaphoreC;
+        private final AtomicInteger _droppedEvents;
+
+        /* package private */ RespectsMaxBufferEventHandler(
+                final Semaphore semaphoreA,
+                final Semaphore semaphoreB,
+                final Semaphore semaphoreC,
+                final AtomicInteger droppedEvents) {
+            _semaphoreA = semaphoreA;
+            _semaphoreB = semaphoreB;
+            _semaphoreC = semaphoreC;
+            _droppedEvents = droppedEvents;
+        }
+
+        @Override
+        public void attemptComplete(
+                final long records,
+                final long bytes,
+                final boolean success,
+                final Quantity elapasedTime) {
+            if (_semaphoreA.availablePermits() == 0) {
+                // Initial synchronization request (leave a an extra permit to mark its completion)
+                _semaphoreA.release(2);
+                try {
+                    _semaphoreB.acquire();
+                } catch (final InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                // Actual buffered requests
+                _semaphoreC.release();
+            }
+        }
+
+        @Override
+        public void droppedEvent(final Event event) {
+            _droppedEvents.incrementAndGet();
+        }
+    }
+
+    private static final class CompletionHandler implements ApacheHttpSinkEventHandler {
+
+        private final Semaphore _semaphore;
+        private final Optional<ApacheHttpSinkEventHandler> _nextHandler;
+
+        /* package private */ CompletionHandler(final Semaphore semaphore) {
+            _semaphore = semaphore;
+            _nextHandler = Optional.empty();
+        }
+
+        /* package private */ CompletionHandler(
+                final Semaphore semaphore,
+                final ApacheHttpSinkEventHandler nextHandler) {
+            _semaphore = semaphore;
+            _nextHandler = Optional.of(nextHandler);
+        }
+
+        @Override
+        public void attemptComplete(
+                final long records,
+                final long bytes,
+                final boolean success,
+                final Quantity elapasedTime) {
+            _semaphore.release();
+            _nextHandler.ifPresent(h -> h.attemptComplete(records, bytes, success, elapasedTime));
+        }
+
+        @Override
+        public void droppedEvent(final Event event) {
+            _nextHandler.ifPresent(h -> h.droppedEvent(event));
+        }
+    }
+
+    private static final class AttemptCompletedAssertionHandler implements ApacheHttpSinkEventHandler {
+
+        private final AtomicBoolean _assertionResult;
+        private final long _expectedRecords;
+        private final long _expectedBytes;
+        private final boolean _expectedSuccess;
+        private final Optional<ApacheHttpSinkEventHandler> _nextHandler;
+
+        /* package private */ AttemptCompletedAssertionHandler(
+                final AtomicBoolean assertionResult,
+                final long expectedRecords,
+                final long expectedBytes,
+                final boolean expectedSuccess) {
+            _assertionResult = assertionResult;
+            _expectedRecords = expectedRecords;
+            _expectedBytes = expectedBytes;
+            _expectedSuccess = expectedSuccess;
+            _nextHandler = Optional.empty();
+        }
+
+        /* package private */ AttemptCompletedAssertionHandler(
+                final AtomicBoolean assertionResult,
+                final long expectedRecords,
+                final long expectedBytes,
+                final boolean expectedSuccess,
+                final ApacheHttpSinkEventHandler nextHandler) {
+            _assertionResult = assertionResult;
+            _expectedRecords = expectedRecords;
+            _expectedBytes = expectedBytes;
+            _expectedSuccess = expectedSuccess;
+            _nextHandler = Optional.of(nextHandler);
+        }
+
+        @Override
+        public void attemptComplete(
+                final long records,
+                final long bytes,
+                final boolean success,
+                final Quantity elapasedTime) {
+            try {
+                Assert.assertEquals(_expectedRecords, records);
+                Assert.assertEquals(_expectedBytes, bytes);
+                Assert.assertEquals(_expectedSuccess, success);
+                _assertionResult.set(true);
+                // CHECKSTYLE.OFF: IllegalCatch - JUnit throws assertions which derive from Throwable
+            } catch (final Throwable t) {
+                // CHECKSTYLE.ON: IllegalCatch
+                _assertionResult.set(false);
+            }
+            _nextHandler.ifPresent(h -> h.attemptComplete(records, bytes, success, elapasedTime));
+        }
+
+        @Override
+        public void droppedEvent(final Event event) {
+            _nextHandler.ifPresent(h -> h.droppedEvent(event));
+        }
+    }
+
+    private static final class EventDroppedAssertionHandler implements ApacheHttpSinkEventHandler {
+
+        private final AtomicInteger _droppedCount;
+        private final Optional<ApacheHttpSinkEventHandler> _nextHandler;
+
+        /* package private */ EventDroppedAssertionHandler(final AtomicInteger droppedCount) {
+            _droppedCount = droppedCount;
+            _nextHandler = Optional.empty();
+        }
+
+        /* package private */ EventDroppedAssertionHandler(
+                final AtomicInteger droppedCount,
+                final ApacheHttpSinkEventHandler nextHandler) {
+            _droppedCount = droppedCount;
+            _nextHandler = Optional.of(nextHandler);
+        }
+
+        @Override
+        public void attemptComplete(
+                final long records,
+                final long bytes,
+                final boolean success,
+                final Quantity elapasedTime) {
+            _nextHandler.ifPresent(h -> h.attemptComplete(records, bytes, success, elapasedTime));
+        }
+
+        @Override
+        public void droppedEvent(final Event event) {
+            _droppedCount.incrementAndGet();
+            _nextHandler.ifPresent(h -> h.droppedEvent(event));
+        }
+    }
+
+    private static class RequestValueMatcher implements ValueMatcher<Request> {
+
+        private final Consumer<ClientV1.Record> _validator;
+
+        /* package private */ RequestValueMatcher(final Consumer<ClientV1.Record> validator) {
+            _validator = validator;
+        }
+
+        @Override
+        public MatchResult match(final Request request) {
+            if (!request.getMethod().equals(RequestMethod.POST)) {
+                System.out.println(String.format(
+                        "Request method does not match; expect=%s, actual=%s",
+                        RequestMethod.POST,
+                        request.getMethod()));
+                return MatchResult.noMatch();
+            }
+            if (!request.getUrl().equals(PATH)) {
+                System.out.println(String.format(
+                        "Request uri does not match; expect=%s, actual=%s",
+                        PATH,
+                        request.getUrl()));
+                return MatchResult.noMatch();
+            }
+            try {
+                final ClientV1.RecordSet recordSet = ClientV1.RecordSet.parseFrom(request.getBody());
+                recordSet.getRecordsList().forEach(_validator::accept);
+                return MatchResult.of(true);
+                // CHECKSTYLE.OFF: IllegalCatch - JUnit throws assertions which derive from Throwable
+            } catch (final Throwable t) {
+                // CHECKSTYLE.ON: IllegalCatch
+                System.out.println("Error parsing body: " + t);
+                t.printStackTrace();
+                return MatchResult.noMatch();
+            }
+        }
+    }
 }


### PR DESCRIPTION
This review addresses:
* #2 - Unit Test Content Assertions
* #4 - Unit Test Synchronization Sleeps
* #5 - Unit Test Failure Assertions

It also addresses #7 (100% Unit Test Coverage) as well as can be given limitations in Jacoco. Namely, it achieves 99% line coverage and 93% branch coverage. The remaining uncovered lines and branches are in the try-with-resources block. I tried rewriting this by hand like we did in the jvm-extra package; however, in this case the finally block was more complex and the generated byte code proved unreachable (the coverage report made no sense). We can either leave #7 open as a reminder or close it with this MR; I'm fine either way.

I am also calling #8 (Dropping Buffered Events) completed as the rate limited logger exists on event drop and now we have metrics as well. Further, it makes no sense really to drop multiple items (the currency makes this either unpredictable or a point of synchronization). Since we're not implementing the multi-drop then there's nothing additional to configure and that addresses all the points in #8 nicely.