### PR TITLE
User Dimensions & Long Bucket Counts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <apache.http.client.version>4.5.10</apache.http.client.version>
     <apache.http.core.version>4.4.12</apache.http.core.version>
     <arpnetworking.commons.version>1.18.1</arpnetworking.commons.version>
-    <client.protocol.version>0.11.1</client.protocol.version>
+    <client.protocol.version>0.11.2</client.protocol.version>
     <hamcrest.version>2.1</hamcrest.version>
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.12</junit.version>

--- a/src/test/java/com/arpnetworking/metrics/impl/ApacheHttpSinkTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/ApacheHttpSinkTest.java
@@ -117,7 +117,8 @@ public final class ApacheHttpSinkTest {
                 WireMock.requestMatching(new RequestValueMatcher(
                         r -> {
                             // Dimensions
-                            Assert.assertEquals(3, r.getDimensionsCount());
+                            Assert.assertEquals(4, r.getDimensionsCount());
+                            assertDimension(r.getDimensionsList(), "foo", "bar");
                             assertDimension(r.getDimensionsList(), "host", "some.host.com");
                             assertDimension(r.getDimensionsList(), "service", "myservice");
                             assertDimension(r.getDimensionsList(), "cluster", "mycluster");
@@ -160,7 +161,7 @@ public final class ApacheHttpSinkTest {
                         new AttemptCompletedAssertionHandler(
                                 assertionResult,
                                 1,
-                                270,
+                                286,
                                 true,
                                 new CompletionHandler(semaphore)))
                 .build();


### PR DESCRIPTION
* Support user defined dimensions. This is not a great implementation (maybe not even good), but it unblocks us and a better solution is forthcoming with client 1.0. 
* Upgrade client protocol to support bucket counts as long (vs int; wire compatible).